### PR TITLE
Issue #81 - Idolos/Equipos por defecto en vista Kaltura/Youtube

### DIFF
--- a/src/Dodici/Fansworld/WebBundle/Controller/VideoController.php
+++ b/src/Dodici/Fansworld/WebBundle/Controller/VideoController.php
@@ -32,6 +32,8 @@ class VideoController extends SiteController
 
     const cantVideos = 20;
     const MIN_ITEMS_CALLTOACTION = 9;
+    const CALLTOACTION_RELATED = 5;
+    const CALLTOACTION_MOSTVIEWS = 2;
 
     /**
      * rightbar
@@ -620,10 +622,15 @@ class VideoController extends SiteController
                 $this->_createIdolTeamArray($entidad, $teams);
         }
 
-        $relatedVideos = $this->getRepository('Video')->related($video, null, 5);
-
+        $relatedVideos = $this->getRepository('Video')->related($video, null, self::CALLTOACTION_RELATED);
         $this->_addMoreData($idols, $relatedVideos, 'idol');
         $this->_addMoreData($teams, $relatedVideos, 'team');
+
+        if (count($idols) < self::MIN_ITEMS_CALLTOACTION || count($teams) < self::MIN_ITEMS_CALLTOACTION) {
+            $mostViewed = $this->getRepository('Video')->search(null, $this->getUser(), self::CALLTOACTION_MOSTVIEWS, null, null, null, null, null, null, 'views');
+            if (count($idols) < self::MIN_ITEMS_CALLTOACTION) $this->_addMoreData($idols, $mostViewed, 'idol');
+            if (count($teams) < self::MIN_ITEMS_CALLTOACTION) $this->_addMoreData($teams, $mostViewed, 'team');
+        }
 
         $response = array(
             'view' => $this->renderView(

--- a/src/Kaltura/APIBundle/Resources/views/iframe.html.twig
+++ b/src/Kaltura/APIBundle/Resources/views/iframe.html.twig
@@ -4,7 +4,7 @@
 </div>
 
 <div data-videocontainer-parent>
-    <div data-videoid="" data-videocontainer>
+    <div data-videoid="{{ video.id }}" data-videocontainer>
         <div id="youtubePlayer">
             <script type="text/javascript">
                 var tagSrcYoutube = document.createElement('script');
@@ -35,9 +35,6 @@
 
                 function autoPlayVideo(event) {
                     event.target.playVideo();
-                }
-                function stopVideo() {
-                    playerYoutube.stopVideo();
                 }
             </script>
         </div>

--- a/src/Kaltura/APIBundle/Services/KalturaTwig.php
+++ b/src/Kaltura/APIBundle/Services/KalturaTwig.php
@@ -24,7 +24,7 @@ class KalturaTwig {
     $this->visitator->visit($video);
     if ($video->getYoutube()) {
       return $this->container->get('templating')->render(
-                      'KalturaAPIBundle::iframe.html.twig', array('idvideo' => $video->getYoutube()));
+                      'KalturaAPIBundle::iframe.html.twig', array('idvideo' => $video->getYoutube(), 'video' => $video));
     } elseif ($video->getVimeo()) {
       return $this->container->get('templating')->render(
                       'KalturaAPIBundle::iframe.html.twig', array(

--- a/web/bundles/dodicifansworldweb/js/main.js
+++ b/web/bundles/dodicifansworldweb/js/main.js
@@ -26,6 +26,9 @@ function playerFinalAction(id) {
                 $('[data-viewagain=' + id + ']').click(function() {
                     $('[data-finalAction-detail=' + id + ']').remove();
                     videoContainer.show();
+                    if ($("[data-viewagain='youtubePlayer']")) {
+                        playerYoutube.playVideo();
+                    }
                 });
             }
         }


### PR DESCRIPTION
Se definieron 3 constantes en videoController.php

const MIN_ITEMS_CALLTOACTION = 9;
const CALLTOACTION_RELATED = 5;
const CALLTOACTION_MOSTVIEWS = 2;
- MIN_ITEMS_CALLTOACTION: La cantidad de Idolos o Equipos que se muestra en el CTA
- CALLTOACTION_RELATED: La cantidad de videos relacionados, donde se va a buscar Idolos/Equipos en caso de que no se cubra la cantidad de Idolos/Equipos de MIN_ITEMS_CALLTOACTION
- CALLTOACTION_MOSTVIEWS: La cantidad de videos mas vistos, en donde se van a buscar Idolos/Equipos en caso que el procedimiento anterior de busqueda de Idolos/Equipos en videos relacionados (CALLTOACTION_RELATED) no llegue al limite de items propuesto por MIN_ITEMS_CALLTOACTION

Esto es para videos de Youtube como para Videos de Kaltura.
